### PR TITLE
Add SwiftUI iPhone weight tracking app

### DIFF
--- a/WeightTracker/README.md
+++ b/WeightTracker/README.md
@@ -1,0 +1,25 @@
+# WeightTracker
+
+An iOS app built with SwiftUI that helps you log your weight, visualize progress, and keep track of long-term trends.
+
+## Features
+
+- Quick logging of weight measurements with optional notes.
+- Automatic replacement of entries logged for the same day.
+- Overview cards highlighting latest weight, weekly change, 30-day average, and longest logging streak.
+- Interactive chart (iOS 16+) to review historical measurements.
+- Persistent storage backed by a lightweight JSON file so that data survives app relaunches.
+- Unit and UI test targets ready for expansion.
+
+## Requirements
+
+- Xcode 15 or later
+- iOS 16.0 or later deployment target
+
+## Getting Started
+
+1. Open `WeightTracker/WeightTracker.xcodeproj` in Xcode.
+2. Select the **WeightTracker** scheme and an iOS simulator or device running iOS 16 or newer.
+3. Build and run.
+
+To execute the bundled tests, choose the **Product ▸ Test** menu in Xcode or run `xcodebuild test -scheme WeightTracker -destination 'platform=iOS Simulator,name=iPhone 15'` from Terminal on macOS.

--- a/WeightTracker/WeightTracker.xcodeproj/project.pbxproj
+++ b/WeightTracker/WeightTracker.xcodeproj/project.pbxproj
@@ -1,0 +1,528 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {
+};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+A1A24D8E29C2C2F600000001 /* WeightTrackerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24D8D29C2C2F600000001 /* WeightTrackerApp.swift */; };
+A1A24D9029C2C30C00000001 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24D8F29C2C30C00000001 /* ContentView.swift */; };
+A1A24D9229C2C32400000001 /* WeightEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24D9129C2C32400000001 /* WeightEntry.swift */; };
+A1A24D9429C2C33D00000001 /* WeightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24D9329C2C33D00000001 /* WeightStore.swift */; };
+A1A24D9729C2C35300000001 /* AddEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24D9529C2C35300000001 /* AddEntryView.swift */; };
+A1A24D9929C2C35300000001 /* StatisticsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24D9829C2C35300000001 /* StatisticsCard.swift */; };
+A1A24D9B29C2C36D00000001 /* TrendChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24D9A29C2C36D00000001 /* TrendChartView.swift */; };
+A1A24D9E29C2C3A900000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1A24D9D29C2C3A900000001 /* Assets.xcassets */; };
+A1A24DA029C2C3C000000001 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1A24D9F29C2C3C000000001 /* Preview Assets.xcassets */; };
+A1A24DBD29C2C49C00000001 /* String+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24DBC29C2C49C00000001 /* String+Utilities.swift */; };
+A1A24DA729C2C40100000001 /* WeightTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24DA629C2C40100000001 /* WeightTrackerTests.swift */; };
+A1A24DAB29C2C41900000001 /* WeightTrackerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24DAA29C2C41900000001 /* WeightTrackerUITests.swift */; };
+A1A24DAE29C2C43300000001 /* WeightTrackerUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A24DAD29C2C43300000001 /* WeightTrackerUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+A1A24DA829C2C40100000001 /* PBXContainerItemProxy */ = {
+isa = PBXContainerItemProxy;
+containerPortal = A1A24D8229C2C2AF00000001 /* Project object */;
+proxyType = 1;
+remoteGlobalIDString = A1A24D8929C2C2F600000001;
+remoteInfo = WeightTracker;
+};
+A1A24DAC29C2C41900000001 /* PBXContainerItemProxy */ = {
+isa = PBXContainerItemProxy;
+containerPortal = A1A24D8229C2C2AF00000001 /* Project object */;
+proxyType = 1;
+remoteGlobalIDString = A1A24D8929C2C2F600000001;
+remoteInfo = WeightTracker;
+};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+A1A24D8C29C2C2F600000001 /* WeightTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeightTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+A1A24D8D29C2C2F600000001 /* WeightTrackerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTrackerApp.swift; sourceTree = "<group>"; };
+A1A24D8F29C2C30C00000001 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+A1A24D9129C2C32400000001 /* WeightEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightEntry.swift; sourceTree = "<group>"; };
+A1A24D9329C2C33D00000001 /* WeightStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightStore.swift; sourceTree = "<group>"; };
+A1A24D9529C2C35300000001 /* AddEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEntryView.swift; sourceTree = "<group>"; };
+A1A24D9829C2C35300000001 /* StatisticsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsCard.swift; sourceTree = "<group>"; };
+A1A24D9A29C2C36D00000001 /* TrendChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendChartView.swift; sourceTree = "<group>"; };
+A1A24DBC29C2C49C00000001 /* String+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Utilities.swift"; sourceTree = "<group>"; };
+A1A24D9D29C2C3A900000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+A1A24D9F29C2C3C000000001 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+A1A24DA229C2C3DE00000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+A1A24DA529C2C40100000001 /* WeightTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WeightTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+A1A24DA629C2C40100000001 /* WeightTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTrackerTests.swift; sourceTree = "<group>"; };
+A1A24DA929C2C41900000001 /* WeightTrackerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WeightTrackerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+A1A24DAA29C2C41900000001 /* WeightTrackerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTrackerUITests.swift; sourceTree = "<group>"; };
+A1A24DAD29C2C43300000001 /* WeightTrackerUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTrackerUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+A1A24D8829C2C2F600000001 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ();
+runOnlyForDeploymentPostprocessing = 0; };
+A1A24DA229C2C40100000001 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ();
+runOnlyForDeploymentPostprocessing = 0; };
+A1A24DA929C2C41900000001 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ();
+runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+A1A24D8129C2C2AF00000001 = {isa = PBXGroup; children = (
+A1A24D8B29C2C2F600000001 /* Products */,
+A1A24DB229C2C46000000001 /* WeightTracker */,
+A1A24DB329C2C46000000001 /* WeightTrackerTests */,
+A1A24DB429C2C46000000001 /* WeightTrackerUITests */
+);
+sourceTree = "<group>"; };
+A1A24D8B29C2C2F600000001 /* Products */ = {isa = PBXGroup; children = (
+A1A24D8C29C2C2F600000001 /* WeightTracker.app */,
+A1A24DA529C2C40100000001 /* WeightTrackerTests.xctest */,
+A1A24DA929C2C41900000001 /* WeightTrackerUITests.xctest */
+);
+sourceTree = "<group>"; };
+A1A24DB229C2C46000000001 /* WeightTracker */ = {isa = PBXGroup; children = (
+A1A24DB529C2C46000000001 /* App */,
+A1A24DB629C2C46000000001 /* Models */,
+A1A24DB729C2C46000000001 /* Persistence */,
+A1A24DB829C2C46000000001 /* Views */,
+A1A24DB929C2C46000000001 /* Resources */
+);
+path = WeightTracker;
+sourceTree = "<group>"; };
+A1A24DB329C2C46000000001 /* WeightTrackerTests */ = {isa = PBXGroup; children = (
+A1A24DA629C2C40100000001 /* WeightTrackerTests.swift */
+);
+path = WeightTrackerTests;
+sourceTree = "<group>"; };
+A1A24DB429C2C46000000001 /* WeightTrackerUITests */ = {isa = PBXGroup; children = (
+A1A24DAA29C2C41900000001 /* WeightTrackerUITests.swift */,
+A1A24DAD29C2C43300000001 /* WeightTrackerUITestsLaunchTests.swift */
+);
+path = WeightTrackerUITests;
+sourceTree = "<group>"; };
+A1A24DB529C2C46000000001 /* App */ = {isa = PBXGroup; children = (
+A1A24D8D29C2C2F600000001 /* WeightTrackerApp.swift */
+);
+path = App;
+sourceTree = "<group>"; };
+A1A24DB629C2C46000000001 /* Models */ = {isa = PBXGroup; children = (
+A1A24D9129C2C32400000001 /* WeightEntry.swift */,
+A1A24DBC29C2C49C00000001 /* String+Utilities.swift */
+);
+path = Models;
+sourceTree = "<group>"; };
+A1A24DB729C2C46000000001 /* Persistence */ = {isa = PBXGroup; children = (
+A1A24D9329C2C33D00000001 /* WeightStore.swift */
+);
+path = Persistence;
+sourceTree = "<group>"; };
+A1A24DB829C2C46000000001 /* Views */ = {isa = PBXGroup; children = (
+A1A24D8F29C2C30C00000001 /* ContentView.swift */,
+A1A24D9529C2C35300000001 /* AddEntryView.swift */,
+A1A24D9829C2C35300000001 /* StatisticsCard.swift */,
+A1A24D9A29C2C36D00000001 /* TrendChartView.swift */
+);
+path = Views;
+sourceTree = "<group>"; };
+A1A24DB929C2C46000000001 /* Resources */ = {isa = PBXGroup; children = (
+A1A24D9D29C2C3A900000001 /* Assets.xcassets */,
+A1A24DBA29C2C46000000001 /* Preview Content */,
+A1A24DA229C2C3DE00000001 /* Info.plist */
+);
+path = Resources;
+sourceTree = "<group>"; };
+A1A24DBA29C2C46000000001 /* Preview Content */ = {isa = PBXGroup; children = (
+A1A24D9F29C2C3C000000001 /* Preview Assets.xcassets */
+);
+path = "Preview Content";
+sourceTree = "<group>"; };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+A1A24D8929C2C2F600000001 /* WeightTracker */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = A1A24DB029C2C42800000001 /* Build configuration list for PBXNativeTarget "WeightTracker" */;
+buildPhases = (
+A1A24D8729C2C2F600000001 /* Sources */,
+A1A24D8829C2C2F600000001 /* Frameworks */,
+A1A24D8A29C2C2F600000001 /* Resources */
+);
+buildRules = (
+);
+dependencies = (
+);
+name = WeightTracker;
+productName = WeightTracker;
+productReference = A1A24D8C29C2C2F600000001 /* WeightTracker.app */;
+productType = "com.apple.product-type.application";
+};
+A1A24DA429C2C40100000001 /* WeightTrackerTests */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = A1A24DB129C2C42800000001 /* Build configuration list for PBXNativeTarget "WeightTrackerTests" */;
+buildPhases = (
+A1A24DA129C2C40100000001 /* Sources */,
+A1A24DA229C2C40100000001 /* Frameworks */,
+A1A24DA329C2C40100000001 /* Resources */
+);
+buildRules = (
+);
+dependencies = (
+A1A24DA929C2C40100000001 /* PBXTargetDependency */
+);
+name = WeightTrackerTests;
+productName = WeightTrackerTests;
+productReference = A1A24DA529C2C40100000001 /* WeightTrackerTests.xctest */;
+productType = "com.apple.product-type.bundle.unit-test";
+};
+A1A24DA829C2C41900000001 /* WeightTrackerUITests */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = A1A24DB229C2C42800000001 /* Build configuration list for PBXNativeTarget "WeightTrackerUITests" */;
+buildPhases = (
+A1A24DA729C2C41900000001 /* Sources */,
+A1A24DA929C2C41900000001 /* Frameworks */,
+A1A24DAA29C2C41900000001 /* Resources */
+);
+buildRules = (
+);
+dependencies = (
+A1A24DAB29C2C41900000001 /* PBXTargetDependency */
+);
+name = WeightTrackerUITests;
+productName = WeightTrackerUITests;
+productReference = A1A24DA929C2C41900000001 /* WeightTrackerUITests.xctest */;
+productType = "com.apple.product-type.bundle.ui-testing";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+A1A24D8229C2C2AF00000001 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+LastSwiftUpdateCheck = 1500;
+LastUpgradeCheck = 1500;
+TargetAttributes = {
+A1A24D8929C2C2F600000001 = {
+CreatedOnToolsVersion = 15.0;
+};
+A1A24DA429C2C40100000001 = {
+CreatedOnToolsVersion = 15.0;
+TestTargetID = A1A24D8929C2C2F600000001;
+};
+A1A24DA829C2C41900000001 = {
+CreatedOnToolsVersion = 15.0;
+TestTargetID = A1A24D8929C2C2F600000001;
+};
+};
+};
+buildConfigurationList = A1A24D8529C2C2AF00000001 /* Build configuration list for PBXProject "WeightTracker" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+Base,
+);
+mainGroup = A1A24D8129C2C2AF00000001;
+productRefGroup = A1A24D8B29C2C2F600000001 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+A1A24D8929C2C2F600000001 /* WeightTracker */,
+A1A24DA429C2C40100000001 /* WeightTrackerTests */,
+A1A24DA829C2C41900000001 /* WeightTrackerUITests */
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+A1A24D8A29C2C2F600000001 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (
+A1A24DA029C2C3C000000001 /* Preview Assets.xcassets in Resources */,
+A1A24D9E29C2C3A900000001 /* Assets.xcassets in Resources */
+);
+runOnlyForDeploymentPostprocessing = 0; };
+A1A24DA329C2C40100000001 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = ();
+runOnlyForDeploymentPostprocessing = 0; };
+A1A24DAA29C2C41900000001 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = ();
+runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+A1A24D8729C2C2F600000001 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
+A1A24DBD29C2C49C00000001 /* String+Utilities.swift in Sources */,
+A1A24D9929C2C35300000001 /* StatisticsCard.swift in Sources */,
+A1A24D9B29C2C36D00000001 /* TrendChartView.swift in Sources */,
+A1A24D9029C2C30C00000001 /* ContentView.swift in Sources */,
+A1A24D9729C2C35300000001 /* AddEntryView.swift in Sources */,
+A1A24D9429C2C33D00000001 /* WeightStore.swift in Sources */,
+A1A24D9229C2C32400000001 /* WeightEntry.swift in Sources */,
+A1A24D8E29C2C2F600000001 /* WeightTrackerApp.swift in Sources */
+);
+runOnlyForDeploymentPostprocessing = 0; };
+A1A24DA129C2C40100000001 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
+A1A24DA729C2C40100000001 /* WeightTrackerTests.swift in Sources */
+);
+runOnlyForDeploymentPostprocessing = 0; };
+A1A24DA729C2C41900000001 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
+A1A24DAE29C2C43300000001 /* WeightTrackerUITestsLaunchTests.swift in Sources */,
+A1A24DAB29C2C41900000001 /* WeightTrackerUITests.swift in Sources */
+);
+runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+A1A24DA929C2C40100000001 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = A1A24D8929C2C2F600000001 /* WeightTracker */; targetProxy = A1A24DA829C2C40100000001 /* PBXContainerItemProxy */; };
+A1A24DAB29C2C41900000001 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = A1A24D8929C2C2F600000001 /* WeightTracker */; targetProxy = A1A24DAC29C2C41900000001 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+A1A24D8629C2C2AF00000001 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_IDENTITY = "Apple Development";
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+};
+name = Debug;
+};
+A1A24D8729C2C2AF00000001 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_IDENTITY = "Apple Development";
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+VALIDATE_PRODUCT = YES;
+};
+name = Release;
+};
+A1A24DB529C2C42800000001 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = WeightTracker/Resources/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.WeightTracker;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Debug;
+};
+A1A24DB629C2C42800000001 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = WeightTracker/Resources/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.WeightTracker;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+};
+name = Release;
+};
+A1A24DB729C2C42800000001 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+BUNDLE_LOADER = "$(TEST_HOST)";
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.WeightTrackerTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+TEST_HOST = "$(BUILT_PRODUCTS_DIR)/WeightTracker.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/WeightTracker";
+};
+name = Debug;
+};
+A1A24DB829C2C42800000001 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+BUNDLE_LOADER = "$(TEST_HOST)";
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.WeightTrackerTests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+TEST_HOST = "$(BUILT_PRODUCTS_DIR)/WeightTracker.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/WeightTracker";
+};
+name = Release;
+};
+A1A24DB929C2C42800000001 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.WeightTrackerUITests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+TEST_TARGET_NAME = WeightTracker;
+};
+name = Debug;
+};
+A1A24DBA29C2C42800000001 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.WeightTrackerUITests;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1";
+TEST_TARGET_NAME = WeightTracker;
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+A1A24D8529C2C2AF00000001 /* Build configuration list for PBXProject "WeightTracker" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+A1A24D8629C2C2AF00000001 /* Debug */,
+A1A24D8729C2C2AF00000001 /* Release */
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+A1A24DB029C2C42800000001 /* Build configuration list for PBXNativeTarget "WeightTracker" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+A1A24DB529C2C42800000001 /* Debug */,
+A1A24DB629C2C42800000001 /* Release */
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+A1A24DB129C2C42800000001 /* Build configuration list for PBXNativeTarget "WeightTrackerTests" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+A1A24DB729C2C42800000001 /* Debug */,
+A1A24DB829C2C42800000001 /* Release */
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+A1A24DB229C2C42800000001 /* Build configuration list for PBXNativeTarget "WeightTrackerUITests" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+A1A24DB929C2C42800000001 /* Debug */,
+A1A24DBA29C2C42800000001 /* Release */
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+};
+rootObject = A1A24D8229C2C2AF00000001 /* Project object */;
+}

--- a/WeightTracker/WeightTracker/App/WeightTrackerApp.swift
+++ b/WeightTracker/WeightTracker/App/WeightTrackerApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct WeightTrackerApp: App {
+    @StateObject private var store = WeightStore()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(store)
+        }
+    }
+}

--- a/WeightTracker/WeightTracker/Models/String+Utilities.swift
+++ b/WeightTracker/WeightTracker/Models/String+Utilities.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension String {
+    func nilIfEmpty() -> String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+extension Optional where Wrapped == String {
+    func nilIfEmpty() -> String? {
+        switch self {
+        case .some(let value):
+            return value.nilIfEmpty()
+        case .none:
+            return nil
+        }
+    }
+}

--- a/WeightTracker/WeightTracker/Models/WeightEntry.swift
+++ b/WeightTracker/WeightTracker/Models/WeightEntry.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct WeightEntry: Identifiable, Codable, Hashable {
+    var id: UUID
+    var date: Date
+    var weight: Double
+    var note: String?
+
+    init(id: UUID = UUID(), date: Date = Date(), weight: Double, note: String? = nil) {
+        self.id = id
+        self.date = date
+        self.weight = weight
+        self.note = note
+    }
+}
+
+extension Array where Element == WeightEntry {
+    func sortedByDateDescending() -> [WeightEntry] {
+        sorted { $0.date > $1.date }
+    }
+
+    func mostRecent(before date: Date) -> WeightEntry? {
+        sortedByDateDescending().first { $0.date < date }
+    }
+}

--- a/WeightTracker/WeightTracker/Persistence/WeightStore.swift
+++ b/WeightTracker/WeightTracker/Persistence/WeightStore.swift
@@ -1,0 +1,174 @@
+import Combine
+import Foundation
+
+@MainActor
+final class WeightStore: ObservableObject {
+    @Published private(set) var entries: [WeightEntry] = []
+
+    private let saveURL: URL
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(preview: Bool = false) {
+        let fileName = preview ? "weights-preview.json" : "weights.json"
+        saveURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(fileName)
+
+        if preview {
+            entries = WeightStore.previewEntries
+        } else {
+            loadEntries()
+        }
+
+        $entries
+            .dropFirst()
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in
+                Task { await self?.persistEntries() }
+            }
+            .store(in: &cancellables)
+    }
+
+    func allEntries() -> [WeightEntry] {
+        entries.sortedByDateDescending()
+    }
+
+    func addEntry(weight: Double, date: Date, note: String?) {
+        var newEntry = WeightEntry(date: date, weight: weight, note: note?.nilIfEmpty())
+        if let existing = entries.first(where: { Calendar.current.isDate($0.date, inSameDayAs: date) }) {
+            newEntry.id = existing.id
+            updateEntry(newEntry)
+        } else {
+            entries.append(newEntry)
+            entries.sort { $0.date > $1.date }
+        }
+    }
+
+    func updateEntry(_ entry: WeightEntry) {
+        guard let index = entries.firstIndex(where: { $0.id == entry.id }) else {
+            entries.append(entry)
+            entries.sort { $0.date > $1.date }
+            return
+        }
+
+        entries[index] = entry
+        entries.sort { $0.date > $1.date }
+    }
+
+    func removeEntries(at offsets: IndexSet) {
+        let sorted = allEntries()
+        let idsToRemove = offsets.map { sorted[$0].id }
+        entries.removeAll { idsToRemove.contains($0.id) }
+    }
+
+    func remove(_ entry: WeightEntry) {
+        entries.removeAll { $0.id == entry.id }
+    }
+
+    // MARK: - Statistics
+
+    var latestEntry: WeightEntry? {
+        entries.sortedByDateDescending().first
+    }
+
+    var weeklyChange: Double? {
+        guard let latest = latestEntry else { return nil }
+        let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: latest.date) ?? latest.date
+        guard let reference = entries.mostRecent(before: weekAgo) else { return nil }
+        return latest.weight - reference.weight
+    }
+
+    var monthlyAverage: Double? {
+        guard let latest = latestEntry else { return nil }
+        guard let monthAgo = Calendar.current.date(byAdding: .day, value: -30, to: latest.date) else { return nil }
+        let range = entries.filter { $0.date >= monthAgo && $0.date <= latest.date }
+        guard !range.isEmpty else { return nil }
+        let total = range.reduce(0) { $0 + $1.weight }
+        return total / Double(range.count)
+    }
+
+    var completionRate: Double {
+        guard let first = entries.sortedByDateDescending().last else { return 0 }
+        guard let last = latestEntry else { return 0 }
+        let days = Calendar.current.dateComponents([.day], from: first.date, to: last.date).day ?? 0
+        if days == 0 { return 1 }
+        let expectedCount = days + 1
+        let ratio = Double(entries.count) / Double(expectedCount)
+        return min(1, max(0, ratio))
+    }
+
+    var longestStreak: Int {
+        let sorted = entries.sorted { $0.date < $1.date }
+        var currentStreak = 0
+        var longest = 0
+        var previousDate: Date?
+
+        for entry in sorted {
+            if let previous = previousDate {
+                if Calendar.current.isDate(entry.date, inSameDayAs: previous) {
+                    continue
+                }
+
+                let difference = Calendar.current.dateComponents([.day], from: previous, to: entry.date).day ?? 0
+                if difference == 1 {
+                    currentStreak += 1
+                } else {
+                    longest = max(longest, currentStreak)
+                    currentStreak = 1
+                }
+            } else {
+                currentStreak = 1
+            }
+
+            previousDate = entry.date
+        }
+
+        return max(longest, currentStreak)
+    }
+
+    var totalChange: Double? {
+        guard let first = entries.sortedByDateDescending().last, let last = latestEntry else { return nil }
+        return last.weight - first.weight
+    }
+
+    // MARK: - Persistence
+
+    private func loadEntries() {
+        do {
+            let data = try Data(contentsOf: saveURL)
+            let decoded = try JSONDecoder().decode([WeightEntry].self, from: data)
+            entries = decoded.sorted { $0.date > $1.date }
+        } catch {
+            entries = []
+        }
+    }
+
+    private func persistEntries() async {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(entries)
+            try data.write(to: saveURL, options: [.atomic])
+        } catch {
+            #if DEBUG
+            print("Failed to persist entries: \(error.localizedDescription)")
+            #endif
+        }
+    }
+
+    func replaceAll(with entries: [WeightEntry]) {
+        self.entries = entries.sorted { $0.date > $1.date }
+    }
+}
+
+private extension WeightStore {
+    static let previewEntries: [WeightEntry] = {
+        let calendar = Calendar.current
+        let baseDate = calendar.startOfDay(for: Date())
+        return stride(from: 0, to: 14, by: 1).map { offset in
+            let date = calendar.date(byAdding: .day, value: -offset, to: baseDate) ?? baseDate
+            let weight = 180 - Double(offset) * 0.5 + Double.random(in: -0.2...0.2)
+            return WeightEntry(date: date, weight: weight, note: offset % 3 == 0 ? "Fasted" : nil)
+        }
+    }()
+}
+

--- a/WeightTracker/WeightTracker/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/WeightTracker/WeightTracker/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WeightTracker/WeightTracker/Resources/Assets.xcassets/Contents.json
+++ b/WeightTracker/WeightTracker/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WeightTracker/WeightTracker/Resources/Info.plist
+++ b/WeightTracker/WeightTracker/Resources/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>WeightTracker</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    </array>
+</dict>
+</plist>

--- a/WeightTracker/WeightTracker/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/WeightTracker/WeightTracker/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WeightTracker/WeightTracker/Views/AddEntryView.swift
+++ b/WeightTracker/WeightTracker/Views/AddEntryView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct AddEntryView: View {
+    @EnvironmentObject private var store: WeightStore
+    @Environment(\.dismiss) private var dismiss
+
+    var entry: WeightEntry?
+
+    @State private var date: Date
+    @State private var weight: Double
+    @State private var note: String
+    @State private var useCurrentTime: Bool
+
+    init(entry: WeightEntry? = nil) {
+        self.entry = entry
+        if let entry {
+            _date = State(initialValue: entry.date)
+            _weight = State(initialValue: entry.weight)
+            _note = State(initialValue: entry.note ?? "")
+            _useCurrentTime = State(initialValue: false)
+        } else {
+            _date = State(initialValue: Date())
+            _weight = State(initialValue: 180)
+            _note = State(initialValue: "")
+            _useCurrentTime = State(initialValue: true)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Measurement") {
+                    DatePicker("Date", selection: $date, displayedComponents: [.date, .hourAndMinute])
+                        .disabled(useCurrentTime)
+                    Toggle("Use current time", isOn: $useCurrentTime)
+                        .onChange(of: useCurrentTime) { _, newValue in
+                            if newValue {
+                                date = Date()
+                            }
+                        }
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            Slider(value: $weight, in: 60...400, step: 0.1) {
+                                Text("Weight")
+                            }
+                            Spacer()
+                            Text(weight, format: .number.precision(.fractionLength(1)))
+                                .frame(width: 60, alignment: .trailing)
+                            Text("lb")
+                                .foregroundColor(.secondary)
+                        }
+                        TextField("Weight", value: $weight, format: .number.precision(.fractionLength(1)))
+                            .keyboardType(.decimalPad)
+                    }
+                    TextField("Notes", text: $note, axis: .vertical)
+                        .lineLimit(3, reservesSpace: true)
+                }
+            }
+            .navigationTitle(entry == nil ? "New Entry" : "Edit Entry")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { saveEntry() }
+                        .disabled(!isValid)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .onAppear {
+            if useCurrentTime {
+                date = Date()
+            }
+        }
+    }
+
+    private var isValid: Bool {
+        weight > 0
+    }
+
+    private func saveEntry() {
+        let finalDate = useCurrentTime ? Date() : date
+        if let entry {
+            let updated = WeightEntry(id: entry.id, date: finalDate, weight: weight, note: note.nilIfEmpty())
+            store.updateEntry(updated)
+        } else {
+            store.addEntry(weight: weight, date: finalDate, note: note)
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    AddEntryView()
+        .environmentObject(WeightStore(preview: true))
+}

--- a/WeightTracker/WeightTracker/Views/ContentView.swift
+++ b/WeightTracker/WeightTracker/Views/ContentView.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var store: WeightStore
+    @State private var showingAddEntry = false
+    @State private var editingEntry: WeightEntry?
+    @State private var displayMode: DisplayMode = .list
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.allEntries().isEmpty {
+                    emptyState
+                } else {
+                    content
+                }
+            }
+            .navigationTitle("Weight Tracker")
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Picker("Display Mode", selection: $displayMode) {
+                        Label("List", systemImage: "list.bullet")
+                            .tag(DisplayMode.list)
+                        Label("Chart", systemImage: "chart.line.uptrend.xyaxis")
+                            .tag(DisplayMode.chart)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                    Button {
+                        showingAddEntry = true
+                    } label: {
+                        Label("Add entry", systemImage: "plus")
+                    }
+                    .accessibilityIdentifier("addEntry")
+                }
+            }
+            .sheet(isPresented: $showingAddEntry) {
+                AddEntryView()
+            }
+            .sheet(item: $editingEntry) { entry in
+                AddEntryView(entry: entry)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "scalemass")
+                .symbolRenderingMode(.hierarchical)
+                .font(.system(size: 64))
+                .foregroundStyle(.tint)
+            Text("Log your first weight entry")
+                .font(.headline)
+            Text("Keep track of trends, stay accountable, and reach your goals by recording your weight daily.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            Button {
+                showingAddEntry = true
+            } label: {
+                Text("Add Entry")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGroupedBackground))
+    }
+
+    private var content: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                summarySection
+                switch displayMode {
+                case .list:
+                    entryList
+                case .chart:
+                    TrendChartView(entries: store.allEntries())
+                        .padding(.horizontal)
+                        .transition(.opacity)
+                }
+            }
+            .padding(.vertical)
+        }
+        .background(Color(.systemGroupedBackground))
+    }
+
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Overview")
+                .font(.title3)
+                .bold()
+                .padding(.horizontal)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    StatisticsCard(title: "Latest", value: formattedWeight(store.latestEntry?.weight), trend: store.weeklyChange.map(formatTrend(_:)))
+                    StatisticsCard(title: "7-day Change", value: store.weeklyChange.map(formatChange), trend: store.totalChange.map(formatTrend(_:)))
+                    StatisticsCard(title: "30-day Avg", value: store.monthlyAverage.map(formatWeight), trend: nil)
+                    StatisticsCard(title: "Consistency", value: store.completionRate.formatted(.percent.precision(.fractionLength(0))), trend: "Longest streak: \(store.longestStreak) days")
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+
+    private var entryList: some View {
+        let entries = store.allEntries()
+        return LazyVStack(spacing: 12) {
+            ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
+                let previous = index + 1 < entries.count ? entries[index + 1] : nil
+                Button {
+                    editingEntry = entry
+                } label: {
+                    EntryRow(entry: entry, previous: previous)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .contextMenu {
+                    Button(role: .destructive) {
+                        store.remove(entry)
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+                Divider()
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    private func formattedWeight(_ weight: Double?) -> String {
+        guard let weight else { return "--" }
+        return formatWeight(weight)
+    }
+
+    private func formatWeight(_ weight: Double) -> String {
+        weight.formatted(.number.precision(.fractionLength(1))) + " lb"
+    }
+
+    private func formatChange(_ change: Double) -> String {
+        let formatted = formatWeight(abs(change))
+        return change >= 0 ? "+\(formatted)" : "-\(formatted)"
+    }
+
+    private func formatTrend(_ change: Double) -> String {
+        let formatter = MeasurementFormatter()
+        formatter.numberFormatter.maximumFractionDigits = 1
+        let measurement = Measurement(value: change, unit: UnitMass.pounds)
+        let string = formatter.string(from: measurement)
+        return change >= 0 ? "+\(string)" : string
+    }
+
+    enum DisplayMode: Hashable {
+        case list
+        case chart
+    }
+}
+
+private struct EntryRow: View {
+    let entry: WeightEntry
+    let previous: WeightEntry?
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(entry.date, format: .dateTime.weekday(.wide).day().month())
+                    .font(.headline)
+                if let note = entry.note {
+                    Text(note)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(entry.weight, format: .number.precision(.fractionLength(1)))
+                    .font(.title3)
+                    .bold()
+                if let change = change(from: previous) {
+                    Text(change)
+                        .font(.caption)
+                        .foregroundStyle(change.hasPrefix("+") ? Color.red : Color.green)
+                }
+            }
+        }
+        .padding()
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func change(from previous: WeightEntry?) -> String? {
+        guard let previous else { return nil }
+        let difference = entry.weight - previous.weight
+        guard difference != 0 else { return nil }
+        let formatted = difference.magnitude.formatted(.number.precision(.fractionLength(1)))
+        return (difference > 0 ? "+" : "-") + formatted + " lb"
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(WeightStore(preview: true))
+}

--- a/WeightTracker/WeightTracker/Views/StatisticsCard.swift
+++ b/WeightTracker/WeightTracker/Views/StatisticsCard.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct StatisticsCard: View {
+    let title: String
+    let value: String?
+    let trend: String?
+
+    init(title: String, value: String?, trend: String?) {
+        self.title = title
+        self.value = value
+        self.trend = trend
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value ?? "--")
+                .font(.title2)
+                .bold()
+            if let trend {
+                Text(trend)
+                    .font(.caption)
+                    .foregroundStyle(color(for: trend))
+            }
+        }
+        .padding()
+        .frame(minWidth: 140, alignment: .leading)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func color(for trend: String) -> Color {
+        if trend.hasPrefix("+") {
+            return .red
+        } else if trend.hasPrefix("-") {
+            return .green
+        } else {
+            return .secondary
+        }
+    }
+}
+
+#Preview {
+    StatisticsCard(title: "Weekly", value: "180.2 lb", trend: "-1.6 lb")
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/WeightTracker/WeightTracker/Views/TrendChartView.swift
+++ b/WeightTracker/WeightTracker/Views/TrendChartView.swift
@@ -1,0 +1,50 @@
+import Charts
+import SwiftUI
+
+struct TrendChartView: View {
+    let entries: [WeightEntry]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Weight Trend")
+                .font(.title3)
+                .bold()
+            if entries.count < 2 {
+                VStack(spacing: 12) {
+                    Image(systemName: "chart.line.uptrend.xyaxis")
+                        .font(.system(size: 40, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Text("Not enough data")
+                        .font(.headline)
+                    Text("Log a few entries to see your weight trend.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: 200)
+            } else {
+                Chart(entries.sortedByDateDescending().reversed()) { entry in
+                    LineMark(
+                        x: .value("Date", entry.date),
+                        y: .value("Weight", entry.weight)
+                    )
+                    PointMark(
+                        x: .value("Date", entry.date),
+                        y: .value("Weight", entry.weight)
+                    )
+                }
+                .chartYAxisLabel("Weight (lb)")
+                .frame(minHeight: 240)
+            }
+        }
+        .padding()
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+#Preview {
+    TrendChartView(entries: WeightStore(preview: true).allEntries())
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/WeightTracker/WeightTrackerTests/WeightTrackerTests.swift
+++ b/WeightTracker/WeightTrackerTests/WeightTrackerTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import WeightTracker
+
+final class WeightTrackerTests: XCTestCase {
+    @MainActor
+    func testAddingEntryInsertsOrReplacesByDate() async throws {
+        let store = WeightStore(preview: true)
+        let date = Calendar.current.startOfDay(for: Date())
+        store.replaceAll(with: [])
+
+        store.addEntry(weight: 180, date: date, note: "Morning")
+        XCTAssertEqual(store.allEntries().count, 1)
+        XCTAssertEqual(store.allEntries().first?.weight, 180)
+
+        store.addEntry(weight: 179.4, date: date, note: "Updated")
+        XCTAssertEqual(store.allEntries().count, 1)
+        XCTAssertEqual(store.allEntries().first?.weight, 179.4)
+    }
+
+    @MainActor
+    func testStatisticsAreComputed() async throws {
+        let store = WeightStore(preview: true)
+        let entries = [
+            WeightEntry(date: Calendar.current.date(byAdding: .day, value: -10, to: Date())!, weight: 190),
+            WeightEntry(date: Calendar.current.date(byAdding: .day, value: -5, to: Date())!, weight: 187),
+            WeightEntry(date: Date(), weight: 185)
+        ]
+        store.replaceAll(with: entries)
+
+        XCTAssertEqual(store.allEntries().count, 3)
+        XCTAssertNotNil(store.latestEntry)
+        XCTAssertNotNil(store.weeklyChange)
+        XCTAssertNotNil(store.monthlyAverage)
+        XCTAssertGreaterThan(store.longestStreak, 0)
+    }
+}

--- a/WeightTracker/WeightTrackerUITests/WeightTrackerUITests.swift
+++ b/WeightTracker/WeightTrackerUITests/WeightTrackerUITests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+final class WeightTrackerUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssertTrue(app.navigationBars["Weight Tracker"].exists)
+        XCTAssertTrue(app.buttons["addEntry"].exists)
+    }
+}

--- a/WeightTracker/WeightTrackerUITests/WeightTrackerUITestsLaunchTests.swift
+++ b/WeightTracker/WeightTrackerUITests/WeightTrackerUITestsLaunchTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+final class WeightTrackerUITestsLaunchTests: XCTestCase {
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Summary
- add a new SwiftUI-based WeightTracker iOS application with entry logging, trend overview, and chart display
- persist weight history with a JSON-backed `WeightStore`, provide add/edit form, and reusable statistics components
- supply unit/UI test targets plus project assets and documentation for building the app in Xcode

## Testing
- not run (requires Xcode on macOS)


------
https://chatgpt.com/codex/tasks/task_e_68cf3b1d53e0832e8a434a1f2910fcfb